### PR TITLE
Adding cytokine submodel to cc3d covid19 model

### DIFF
--- a/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/Coronavirus.py
+++ b/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/Coronavirus.py
@@ -29,4 +29,9 @@ CompuCellSetup.register_steppable(steppable=RecoverySteppable(frequency=1))
 from CoronavirusSteppables import ImmuneCellSeedingSteppable
 CompuCellSetup.register_steppable(steppable=ImmuneCellSeedingSteppable(frequency=1))
 
+
+        
+from CoronavirusSteppables import CytokineProductionAbsorptionSteppable
+CompuCellSetup.register_steppable(steppable=CytokineProductionAbsorptionSteppable(frequency=1))
+
 CompuCellSetup.run()

--- a/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/Coronavirus.xml
+++ b/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/Coronavirus.xml
@@ -85,6 +85,24 @@
             </Plane>
          </BoundaryConditions>
       </DiffusionField>
+      <DiffusionField Name="cytokine">
+         <DiffusionData>
+            <FieldName>cytokine</FieldName>
+            <GlobalDiffusionConstant id = "cytokine_dc">10.0</GlobalDiffusionConstant>
+            <GlobalDecayConstant id = "cytokine_decay">0</GlobalDecayConstant>
+         </DiffusionData>
+         <BoundaryConditions>
+            <Plane Axis="X">
+               <Periodic/>
+            </Plane>
+            <Plane Axis="Y">
+               <Periodic/>
+            </Plane>
+            <Plane Axis="Z">
+               <Periodic/>
+            </Plane>
+         </BoundaryConditions>
+      </DiffusionField>
    </Steppable>
 
 </CompuCell3D>

--- a/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/Coronavirus.xml
+++ b/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/Coronavirus.xml
@@ -61,6 +61,8 @@
    <Plugin Name="Chemotaxis">
         <ChemicalField Name="Virus">
         </ChemicalField>
+        <ChemicalField Name="cytokine">
+        </ChemicalField>
    </Plugin>
    
    <Plugin Name="Secretion">

--- a/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
+++ b/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
@@ -67,9 +67,9 @@ cytokine_dc = exp_cytokine_dc_cyto * s_to_mcs / (um_to_lat_width ** 2) # CK diff
 
 # pM = pmol/L = pmol/(10^15 um^3) = 10^-15 pmol/(um^3) = 10^-15 * um_to_lat_width^3 pmol/pixel
 # pM/s = pM * s_to_mcs / MCS
-max_ck_consume = exp_max_cytokine_consumption_mol * um_to_lat_width**3 * s_to_mcs * 1e-15 #  * pmol/(pixel seconds)
-max_ck_secrete_im = exp_max_cytokine_immune_secretion_mol * um_to_lat_width**3 * s_to_mcs * 1e-15 #  * pmol/(pixel seconds)
-EC50_ck_immune = exp_EC50_cytokine_immune * um_to_lat_width**3  * 1e-15 #  * pmol/pixel
+max_ck_consume = exp_max_cytokine_consumption_mol * um_to_lat_width**3 * s_to_mcs  # * 1e-15 * pmol/(pixel seconds)
+max_ck_secrete_im = exp_max_cytokine_immune_secretion_mol * um_to_lat_width**3 * s_to_mcs  # * 1e-15 * pmol/(pixel seconds)
+EC50_ck_immune = exp_EC50_cytokine_immune * um_to_lat_width**3   #* 1e-15  * pmol/pixel
 
 # Threshold at which cell infection is evaluated
 cell_infection_threshold = 1.0

--- a/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
+++ b/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
@@ -400,18 +400,26 @@ class ChemotaxisSteppable(SteppableBasePy):
 
     def start(self):
         for cell in self.cell_list_by_type(self.IMMUNECELL):
-            cd = self.chemotaxisPlugin.addChemotaxisData(cell, "Virus")
-            cd.setLambda(50.0)
+            
+            cd = self.chemotaxisPlugin.addChemotaxisData(cell, "cytokine")
+            if cell.dict['activated']:
+                cd.setLambda(50.0)
+            else:
+                cd.setLambda(0.0)
             cd.assignChemotactTowardsVectorTypes([self.MEDIUM])
 
     def step(self, mcs):
         field = self.field.Virus
         for cell in self.cell_list_by_type(self.IMMUNECELL):
-            cd = self.chemotaxisPlugin.getChemotaxisData(cell, "Virus")
+            
+            cd = self.chemotaxisPlugin.getChemotaxisData(cell, "cytokine")
             concentration = field[cell.xCOM, cell.yCOM, 0]
             constant = 50.0
             l = constant / (1.0 + concentration)
-            cd.setLambda(l)
+            if cell.dict['activated']:
+                cd.setLambda(l)
+            else:
+                cd.setLambda(0)
 
 
 class RecoverySteppable(SteppableBasePy):
@@ -474,8 +482,11 @@ class ImmuneCellSeedingSteppable(SteppableBasePy):
                 cell.dict['tot_ck_upt'] = 0
                 
                 self.cellField[x_seed:x_seed + int(cell_diameter), y_seed:y_seed + int(cell_diameter), 1] = cell
-                cd = self.chemotaxisPlugin.addChemotaxisData(cell, "Virus")
-                cd.setLambda(50.0)
+                cd = self.chemotaxisPlugin.addChemotaxisData(cell, "cytokine")
+                if cell.dict['activated']:
+                    cd.setLambda(50.0)
+                else:
+                    cd.setLambda(0.0)
                 cd.assignChemotactTowardsVectorTypes([self.MEDIUM])
                 cell.targetVolume = cell_volume
                 cell.lambdaVolume = cell_volume

--- a/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
+++ b/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
@@ -516,6 +516,10 @@ class CytokineProductionAbsorptionSteppable(SteppableBasePy):
             up_res = self.ck_secretor.uptakeInsideCellTotalCount(cell, 
                     max_ck_consume/cell.volume, 0.1)
             
+            cell.dict['tot_ck_upt'] -= up_res.total_count #from POV of secretion uptake is negative
+            
+            if cell.dict['tot_ck_upt'] >= EC50_ck_immune:
+                cell.dict['activated'] = True
             
             if cell.dict['activated']:
                 sec_res = self.ck_secretor.secreteInsideCellTotalCount(cell, 

--- a/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
+++ b/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
@@ -67,9 +67,9 @@ cytokine_dc = exp_cytokine_dc_cyto * s_to_mcs / (um_to_lat_width ** 2) # CK diff
 
 # pM = pmol/L = pmol/(10^15 um^3) = 10^-15 pmol/(um^3) = 10^-15 * um_to_lat_width^3 pmol/pixel
 # pM/s = pM * s_to_mcs / MCS
-max_ck_consume = exp_max_cytokine_consumption_mol * um_to_lat_width**3 * s_to_mcs # 1e-15 * pmol/(pixel seconds)
-max_ck_secrete_im = exp_max_cytokine_immune_secretion_mol * um_to_lat_width**3 * s_to_mcs # 1e-15 * pmol/(pixel seconds)
-EC50_ck_immune = exp_EC50_cytokine_immune * um_to_lat_width**3 # 1e-15 * pmol/pixel
+max_ck_consume = exp_max_cytokine_consumption_mol * um_to_lat_width**3 * s_to_mcs * 1e-15 #  * pmol/(pixel seconds)
+max_ck_secrete_im = exp_max_cytokine_immune_secretion_mol * um_to_lat_width**3 * s_to_mcs * 1e-15 #  * pmol/(pixel seconds)
+EC50_ck_immune = exp_EC50_cytokine_immune * um_to_lat_width**3  * 1e-15 #  * pmol/pixel
 
 # Threshold at which cell infection is evaluated
 cell_infection_threshold = 1.0
@@ -489,9 +489,9 @@ class CytokineProductionAbsorptionSteppable(SteppableBasePy):
 
 
     def step(self, mcs):
-        print("CytokineProductionAbsorptionSteppable: This function is called every 1 MCS")
 
         for cell in self.cell_list_by_type(self.IMMUNECELL, self.INFECTED):
+            print(cell.volume)
             # ck secretion
             cell.dict['ck_production'] = max_ck_secrete_im ##TODO: replace secretion by hill
             cell.dict['ck_consumption'] = max_ck_consume ##TODO: replace by hill

--- a/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
+++ b/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
@@ -34,12 +34,14 @@ cytoplasm_density = 6 # unit = [density of water](B)
 
 exp_cytokine_dc_w = 100 # um^2/s; diffusion constant in water (A,B)
 exp_cytokine_dc_cyto = 16 # um^2/s; estimated diffusion constant in cytoplasm (B)
+
 exp_max_cytokine_consumption = 1 # molecule / (cell second); maximum consumption of cytokine; actually a range [0.3,1] molecule / (cell second) (A)
 exp_max_cytokine_immune_secretion = 10 # molecule / (cell second) (B)
 
 exp_max_cytokine_consumption_mol = 3.5e-4 # pM/s
 exp_max_cytokine_immune_secretion_mol = 3.5e-3 # pM/s
 
+exp_EC50_cytokine_immune = 50 # pM from (B)
 
 
 ##=============================

--- a/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
+++ b/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
@@ -271,7 +271,7 @@ class CellsInitializerSteppable(SteppableBasePy):
             #cyttokine params
             cell.dict['ck_production'] = max_ck_secrete_im ##TODO: replace secretion by hill
             cell.dict['ck_consumption'] = max_ck_consume ##TODO: replace by hill
-            
+            cell.dict['tot_ck_upt'] = 0
             
 
 class Viral_ReplicationSteppable(SteppableBasePy):
@@ -334,7 +334,6 @@ class Viral_ReplicationSteppable(SteppableBasePy):
                 
                 #cyttokine params
                 cell.dict['ck_production'] = max_ck_secrete_im ##TODO: replace secretion by hill
-                cell.dict['ck_consumption'] = max_ck_consume ##TODO: replace by hill
                 
 
             # Test for cell death
@@ -469,6 +468,7 @@ class ImmuneCellSeedingSteppable(SteppableBasePy):
                 #cyttokine params
                 cell.dict['ck_production'] = max_ck_secrete_im ##TODO: replace secretion by hill
                 cell.dict['ck_consumption'] = max_ck_consume ##TODO: replace by hill
+                cell.dict['tot_ck_upt'] = 0
                 
                 self.cellField[x_seed:x_seed + int(cell_diameter), y_seed:y_seed + int(cell_diameter), 1] = cell
                 cd = self.chemotaxisPlugin.addChemotaxisData(cell, "Virus")

--- a/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
+++ b/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
@@ -1,7 +1,7 @@
 ###############################################################################################################
 # To cite this model please use the following:
 #
-# Josua Aponte-Serrano, T.J. Sego, James A. Glazier,
+# Josua Aponte-Serrano, T.J. Sego, Juliano F. Gianlupi, James A. Glazier,
 # "Model of Viral Tissue Infection"
 # https://github.com/covid-tissue-models/covid-tissue-response-models/tree/master/tellurium/simple_virus_model
 ###############################################################################################################

--- a/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
+++ b/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
@@ -39,7 +39,7 @@ exp_cytokine_dc_cyto = 16 # um^2/s; estimated diffusion constant in cytoplasm (B
 exp_max_cytokine_consumption = 1 # molecule / (cell second); maximum consumption of cytokine; actually a range [0.3,1] molecule / (cell second) (A)
 exp_max_cytokine_immune_secretion = 10 # molecule / (cell second) (B)
 
-exp_max_cytokine_consumption_mol = 3.5e-4 # pM/s
+exp_max_cytokine_consumption_mol = 3.5e-4 # pM/s 
 exp_max_cytokine_immune_secretion_mol = 3.5e-3 # pM/s
 
 exp_EC50_cytokine_immune = 50 # pM from (B)
@@ -59,6 +59,16 @@ replicating_rate = exp_replicating_rate * s_to_mcs
 translating_rate = exp_translating_rate * s_to_mcs
 packing_rate = exp_packing_rate * s_to_mcs
 secretion_rate = exp_secretion_rate * s_to_mcs
+
+## cytokine
+
+cytokine_dc = exp_cytokine_dc_cyto * s_to_mcs / (um_to_lat_width ** 2) # CK diff cst
+
+# pM = pmol/L = pmol/(10^15 um^3) = 10^-15 pmol/(um^3) = 10^-15 * um_to_lat_width^3 pmol/pixel
+# pM/s = pM * s_to_mcs / MCS
+max_ck_consume = exp_max_cytokine_consumption_mol * um_to_lat_width**3 * s_to_mcs # 1e-15 * pmol/(pixel seconds)
+max_ck_secrete_im = exp_max_cytokine_immune_secretion_mol * um_to_lat_width**3 * s_to_mcs # 1e-15 * pmol/(pixel seconds)
+EC50_ck_immune = EC50_cytokine_immune * um_to_lat_width**3 # 1e-15 * pmol/pixel
 
 # Threshold at which cell infection is evaluated
 cell_infection_threshold = 1.0

--- a/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
+++ b/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
@@ -26,6 +26,23 @@ exp_secretion_rate = exp_replicating_rate
 
 exp_virus_dc = 10.0 / 100.0  # um^2/s
 
+# cytokines:
+# data from https://www.sciencedirect.com/science/article/pii/S1074761317300924 supplemental materials (A)
+# and
+# from https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3433682/ (B)
+cytoplasm_density = 6 # unit = [density of water](B)
+
+exp_cytokine_dc_w = 100 # um^2/s; diffusion constant in water (A,B)
+exp_cytokine_dc_cyto = 16 # um^2/s; estimated diffusion constant in cytoplasm (B)
+exp_max_cytokine_consumption = 1 # molecule / (cell second); maximum consumption of cytokine; actually a range [0.3,1] molecule / (cell second) (A)
+exp_max_cytokine_immune_secretion = 10 # molecule / (cell second) (B)
+
+exp_max_cytokine_consumption_mol = 3.5e-4 # pM/s
+exp_max_cytokine_immune_secretion_mol = 3.5e-3 # pM/s
+
+
+
+##=============================
 # CompuCell Parameters
 cell_diameter = exp_cell_diameter * 1.0 / um_to_lat_width
 cell_volume = cell_diameter ** 2

--- a/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
+++ b/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
@@ -16,6 +16,9 @@ vrl_key = 'viral_replication_loaded'  # Internal use; do not remove
 s_to_mcs = 120.0  # s/mcs
 um_to_lat_width = 4.0  # um/lattice_length
 
+pmol_to_cc3d_au = 1e15
+
+
 # Experimental Parameters
 exp_cell_diameter = 12.0  # um
 
@@ -67,9 +70,9 @@ cytokine_dc = exp_cytokine_dc_cyto * s_to_mcs / (um_to_lat_width ** 2) # CK diff
 
 # pM = pmol/L = pmol/(10^15 um^3) = 10^-15 pmol/(um^3) = 10^-15 * um_to_lat_width^3 pmol/pixel
 # pM/s = pM * s_to_mcs / MCS
-max_ck_consume = exp_max_cytokine_consumption_mol * um_to_lat_width**3 * s_to_mcs  # * 1e-15 * pmol/(pixel seconds)
-max_ck_secrete_im = exp_max_cytokine_immune_secretion_mol * um_to_lat_width**3 * s_to_mcs  # * 1e-15 * pmol/(pixel seconds)
-EC50_ck_immune = exp_EC50_cytokine_immune * um_to_lat_width**3   #* 1e-15  * pmol/pixel
+max_ck_consume = exp_max_cytokine_consumption_mol * um_to_lat_width**3 * s_to_mcs  * 1e-15 * pmol_to_cc3d_au#  cc3d_au/(pixel seconds)
+max_ck_secrete_im = exp_max_cytokine_immune_secretion_mol * um_to_lat_width**3 * s_to_mcs * 1e-15  * pmol_to_cc3d_au# * cc3d_au/(pixel seconds)
+EC50_ck_immune = exp_EC50_cytokine_immune * um_to_lat_width**3 * 1e-15 * pmol_to_cc3d_au #   * cc3d_au/pixel
 
 # Threshold at which cell infection is evaluated
 cell_infection_threshold = 1.0

--- a/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
+++ b/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
@@ -267,6 +267,11 @@ class CellsInitializerSteppable(SteppableBasePy):
             self.cellField[x:x + int(cell_diameter), y:y + int(cell_diameter), 1] = cell
             cell.targetVolume = cell_volume
             cell.lambdaVolume = cell_volume
+            cell.dict['activated'] = False # flag for immune cell being naive or activated
+            #cyttokine params
+            cell.dict['ck_production'] = max_ck_secrete_im ##TODO: replace secretion by hill
+            cell.dict['ck_consumption'] = max_ck_consume ##TODO: replace by hill
+            
             
 
 class Viral_ReplicationSteppable(SteppableBasePy):
@@ -326,6 +331,11 @@ class Viral_ReplicationSteppable(SteppableBasePy):
             if cell.dict['Assembled'] > cell_infection_threshold:
                 cell.type = self.INFECTED
                 enable_viral_secretion(cell)
+                
+                #cyttokine params
+                cell.dict['ck_production'] = max_ck_secrete_im ##TODO: replace secretion by hill
+                cell.dict['ck_consumption'] = max_ck_consume ##TODO: replace by hill
+                
 
             # Test for cell death
             if cell.dict['Assembled'] > cell_death_threshold:
@@ -456,6 +466,10 @@ class ImmuneCellSeedingSteppable(SteppableBasePy):
             if open_space:
                 cell = self.new_cell(self.IMMUNECELL)
                 cell.dict['activated'] = False # flag for immune cell being naive or activated
+                #cyttokine params
+                cell.dict['ck_production'] = max_ck_secrete_im ##TODO: replace secretion by hill
+                cell.dict['ck_consumption'] = max_ck_consume ##TODO: replace by hill
+                
                 self.cellField[x_seed:x_seed + int(cell_diameter), y_seed:y_seed + int(cell_diameter), 1] = cell
                 cd = self.chemotaxisPlugin.addChemotaxisData(cell, "Virus")
                 cd.setLambda(50.0)
@@ -490,14 +504,31 @@ class CytokineProductionAbsorptionSteppable(SteppableBasePy):
 
     def step(self, mcs):
 
-        for cell in self.cell_list_by_type(self.IMMUNECELL, self.INFECTED):
-            print(cell.volume)
-            # ck secretion
-            cell.dict['ck_production'] = max_ck_secrete_im ##TODO: replace secretion by hill
-            cell.dict['ck_consumption'] = max_ck_consume ##TODO: replace by hill
+        for cell in self.cell_list_by_type(self.INFECTED):
+            
             res = self.ck_secretor.secreteInsideCellTotalCount(cell, 
                                 max_ck_secrete_im/cell.volume)
-
+        
+        
+        
+        for cell in self.cell_list_by_type(self.IMMUNECELL):
+            print(EC50_ck_immune)
+            up_res = self.ck_secretor.uptakeInsideCellTotalCount(cell, 
+                    max_ck_consume/cell.volume, 0.1)
+            
+            
+            if cell.dict['activated']:
+                sec_res = self.ck_secretor.secreteInsideCellTotalCount(cell, 
+                                max_ck_secrete_im/cell.volume)
+            
+            
+            
+            
+    
+    
+    
+    
+    
 
     def finish(self):
         # this function may be called at the end of simulation - used very infrequently though

--- a/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
+++ b/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
@@ -42,7 +42,7 @@ exp_max_cytokine_immune_secretion = 10 # molecule / (cell second) (B)
 exp_max_cytokine_consumption_mol = 3.5e-4 # pM/s 
 exp_max_cytokine_immune_secretion_mol = 3.5e-3 # pM/s
 
-exp_EC50_cytokine_immune = 50 # pM from (B)
+exp_EC50_cytokine_immune = 1 # pM from (B), it's a range from [1,50]pM
 
 
 ##=============================
@@ -512,16 +512,17 @@ class CytokineProductionAbsorptionSteppable(SteppableBasePy):
         
         
         for cell in self.cell_list_by_type(self.IMMUNECELL):
-            
+            #print(EC50_ck_immune)
             up_res = self.ck_secretor.uptakeInsideCellTotalCount(cell, 
                     max_ck_consume/cell.volume, 0.1)
             
-            cell.dict['tot_ck_upt'] -= up_res.total_count #from POV of secretion uptake is negative
-            
+            cell.dict['tot_ck_upt'] -= up_res.tot_amount #from POV of secretion uptake is negative
+            #print('tot_upt',cell.dict['tot_ck_upt'],'upt_now',up_res.tot_amount)
             if cell.dict['tot_ck_upt'] >= EC50_ck_immune:
                 cell.dict['activated'] = True
             
             if cell.dict['activated']:
+                #print('activated', cell.id)
                 sec_res = self.ck_secretor.secreteInsideCellTotalCount(cell, 
                                 max_ck_secrete_im/cell.volume)
             

--- a/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
+++ b/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
@@ -481,6 +481,8 @@ class ImmuneCellSeedingSteppable(SteppableBasePy):
 class CytokineProductionAbsorptionSteppable(SteppableBasePy):
     def __init__(self, frequency=1):
         SteppableBasePy.__init__(self, frequency)
+        self.track_cell_level_scalar_attribute(field_name='activated', attribute_name='activated')
+        
         
 
     def start(self):
@@ -488,12 +490,13 @@ class CytokineProductionAbsorptionSteppable(SteppableBasePy):
         self.get_xml_element('cytokine_dc').cdata = cytokine_dc
         self.get_xml_element('cytokine_decay').cdata = 0 # no "natural" decay, only consumption
         
-        for cell in self.cell_list_by_type(self.IMMUNECELL, self.INFECTED):
+        for cell in self.cell_list_by_type(self.IMMUNECELL):
             ## TODO: differentiate this rates between the cell types
             # cytokine production/uptake parameters for immune cells
             cell.dict['ck_production'] = max_ck_secrete_im ##TODO: replace secretion by hill
             cell.dict['ck_consumption'] = max_ck_consume ##TODO: replace by hill
-        
+        for cell in self.cell_list_by_type(self.INFECTED):
+            cell.dict['ck_production'] = max_ck_secrete_im ##TODO: replace secretion by hill
         
         # Make sure Secretion plugin is loaded
         # make sure this field is defined in one of the PDE solvers

--- a/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
+++ b/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
@@ -404,7 +404,7 @@ class ChemotaxisSteppable(SteppableBasePy):
             
             cd = self.chemotaxisPlugin.addChemotaxisData(cell, "cytokine")
             if cell.dict['activated']:
-                cd.setLambda(50.0)
+                cd.setLambda(50.0/10)
             else:
                 cd.setLambda(0.0)
             cd.assignChemotactTowardsVectorTypes([self.MEDIUM])
@@ -415,7 +415,7 @@ class ChemotaxisSteppable(SteppableBasePy):
             
             cd = self.chemotaxisPlugin.getChemotaxisData(cell, "cytokine")
             concentration = field[cell.xCOM, cell.yCOM, 0]
-            constant = 50.0
+            constant = 50.0/10
             l = constant / (1.0 + concentration)
             if cell.dict['activated']:
                 cd.setLambda(l)

--- a/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
+++ b/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
@@ -20,7 +20,7 @@ pmol_to_cc3d_au = 1e15
 
 
 # Experimental Parameters
-exp_cell_diameter = 12.0  # um
+exp_cell_diameter = 12.0  # um 
 
 exp_replicating_rate = 1.0 / 20.0 * 1.0 / 60.0  # 1.0/20.0min * 1.0min/60.0s = 1.0/1200.0s
 exp_translating_rate = exp_replicating_rate * 2.0  #
@@ -37,7 +37,8 @@ exp_virus_dc = 10.0 / 100.0  # um^2/s
 cytoplasm_density = 6 # unit = [density of water](B)
 
 exp_cytokine_dc_w = 100 # um^2/s; diffusion constant in water (A,B)
-exp_cytokine_dc_cyto = 16 # um^2/s; estimated diffusion constant in cytoplasm (B)
+#the division by 10 is due to the small lattice size, as fiscussed with josh. we all should discuss this matter
+exp_cytokine_dc_cyto = 16/10 # um^2/s; estimated diffusion constant in cytoplasm (B)
 
 exp_max_cytokine_consumption = 1 # molecule / (cell second); maximum consumption of cytokine; actually a range [0.3,1] molecule / (cell second) (A)
 exp_max_cytokine_immune_secretion = 10 # molecule / (cell second) (B)

--- a/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
+++ b/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
@@ -512,7 +512,7 @@ class CytokineProductionAbsorptionSteppable(SteppableBasePy):
         
         
         for cell in self.cell_list_by_type(self.IMMUNECELL):
-            print(EC50_ck_immune)
+            
             up_res = self.ck_secretor.uptakeInsideCellTotalCount(cell, 
                     max_ck_consume/cell.volume, 0.1)
             

--- a/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
+++ b/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
@@ -238,6 +238,12 @@ class CellsInitializerSteppable(SteppableBasePy):
     def start(self):
         self.get_xml_element('virus_dc').cdata = virus_dc
         self.get_xml_element('virus_decay').cdata = virus_decay
+        
+        # cytokine diff parameters        
+        self.get_xml_element('cytokine_dc').cdata = cytokine_dc
+        self.get_xml_element('cytokine_decay').cdata = 0 # no "natural" decay, only consumption
+        
+        
         for x in range(0, self.dim.x, int(cell_diameter)):
             for y in range(0, self.dim.y, int(cell_diameter)):
                 cell = self.new_cell(self.UNINFECTED)
@@ -265,6 +271,9 @@ class CellsInitializerSteppable(SteppableBasePy):
             self.cellField[x:x + int(cell_diameter), y:y + int(cell_diameter), 1] = cell
             cell.targetVolume = cell_volume
             cell.lambdaVolume = cell_volume
+            # cytokine production/uptake parameters for immune cells
+            cell.dict['immune_production'] = max_ck_secrete_im ##TODO: replace secretion by hill
+            cell.dict['immune_consumption'] = max_ck_consume ##TODO: replace by hill
 
 
 class Viral_ReplicationSteppable(SteppableBasePy):

--- a/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
+++ b/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
@@ -455,6 +455,7 @@ class ImmuneCellSeedingSteppable(SteppableBasePy):
                         y_seed = yi
             if open_space:
                 cell = self.new_cell(self.IMMUNECELL)
+                cell.dict['activated'] = False # flag for immune cell being naive or activated
                 self.cellField[x_seed:x_seed + int(cell_diameter), y_seed:y_seed + int(cell_diameter), 1] = cell
                 cd = self.chemotaxisPlugin.addChemotaxisData(cell, "Virus")
                 cd.setLambda(50.0)


### PR DESCRIPTION
The cytokine submodel is usable. I want to discuss it before pulling it into the main code.

Submodel verbal description: 

Immune cells may be inactivated (naive) or activated (trained to hunt invaders). All immune cells (activated or not) uptake cytokines (ck). After uptaking a certain amount (EC50, defined in the code) immune cells become activated. Activated immune cells chemotax on the ck field. They also secrete ck (at a rate 10x the rate of uptake). 

Infected (self.INFECTED) cells secrete cytokines (ck) into the environment (for now I am using the same same rate as activated immune, I haven't found an experimental number for them yet).

Cytokines **do not** decay, they are only uptaken. With the simulation as is ck diffuses way faster than virus, whole lattice field becomes same value fast. According to Josh virus D is lower than in reality, it should be closer to ck D. The way to solve the saturation of the field might be to increase lattice and diminish how many um is the side of a pixel.  

TBD: 

- replace instant activation for a probability of activation that depends on amount of ck uptaken (most likely a Hill)
- have some decay on the amount of ck uptaken (otherwise immune cells will have a memory that goes back to the beginning of Time)
- find a good ck secretion rate for infected cells
- replace constant rate of secretion/absorption for something that looks sigmoidal (don't know what would be the controlling variable; density of virus inside cytoplasm for the infected seems logical, not sure what could be a good one for activated immunes)
- fine tuning of ck diffusion constants. 

Do all of you feel that it is in an ok state to be part of the main code?