### PR TITLE
Cc3d/adjustment/ck secretion chemotaxis

### DIFF
--- a/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
+++ b/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
@@ -79,6 +79,9 @@ max_ck_consume = exp_max_cytokine_consumption_mol * um_to_lat_width ** 3 * s_to_
 max_ck_secrete_im = exp_max_cytokine_immune_secretion_mol * um_to_lat_width ** 3 * s_to_mcs * 1e-15 * pmol_to_cc3d_au  # * cc3d_au/(pixel seconds)
 EC50_ck_immune = exp_EC50_cytokine_immune * um_to_lat_width ** 3 * 1e-15 * pmol_to_cc3d_au  # * cc3d_au/pixel
 
+max_ck_secrete_infect = max_ck_secrete_im
+
+
 # Threshold at which cell infection is evaluated
 cell_infection_threshold = 1.0
 # Threshold at which cell death is evaluated
@@ -357,7 +360,7 @@ class Viral_ReplicationSteppable(SteppableBasePy):
                 enable_viral_secretion(cell)
 
                 # cyttokine params
-                cell.dict['ck_production'] = max_ck_secrete_im  # TODO: replace secretion by hill
+                cell.dict['ck_production'] = max_ck_secrete_infect  # TODO: replace secretion by hill
 
             # Test for cell death
             if cell.dict['Assembled'] > cell_death_threshold:
@@ -647,7 +650,7 @@ class CytokineProductionAbsorptionSteppable(SteppableBasePy):
             cell.dict['ck_production'] = max_ck_secrete_im  # TODO: replace secretion by hill
             cell.dict['ck_consumption'] = max_ck_consume  # TODO: replace by hill
         for cell in self.cell_list_by_type(self.INFECTED):
-            cell.dict['ck_production'] = max_ck_secrete_im  # TODO: replace secretion by hill
+            cell.dict['ck_production'] = max_ck_secrete_infect  # TODO: replace secretion by hill
 
         # Make sure Secretion plugin is loaded
         # make sure this field is defined in one of the PDE solvers
@@ -659,14 +662,14 @@ class CytokineProductionAbsorptionSteppable(SteppableBasePy):
 
         for cell in self.cell_list_by_type(self.INFECTED):
             res = self.ck_secretor.secreteInsideCellTotalCount(cell,
-                                                               max_ck_secrete_im / cell.volume)
+                                                               cell.dict['ck_production'] / cell.volume)
 
         for cell in self.cell_list_by_type(self.IMMUNECELL):
             # print(EC50_ck_immune)
             up_res = self.ck_secretor.uptakeInsideCellTotalCount(cell,
-                                                                 max_ck_consume / cell.volume, 0.1)
+                                                                 cell.dict['ck_consumption'] / cell.volume, 0.1)
             # Added virus uptake
-            self.virus_secretor.uptakeInsideCellTotalCount(cell,max_ck_consume / cell.volume, 0.1)
+            self.virus_secretor.uptakeInsideCellTotalCount(cell,cell.dict['ck_consumption'] / cell.volume, 0.1)
 
             cell.dict['tot_ck_upt'] -= up_res.tot_amount  # from POV of secretion uptake is negative
             print('tot_upt',cell.dict['tot_ck_upt'],'upt_now',up_res.tot_amount)
@@ -676,4 +679,4 @@ class CytokineProductionAbsorptionSteppable(SteppableBasePy):
             if cell.dict['activated']:
                 # print('activated', cell.id)
                 sec_res = self.ck_secretor.secreteInsideCellTotalCount(cell,
-                                                                       max_ck_secrete_im / cell.volume)
+                                                                       cell.dict['ck_production'] / cell.volume)

--- a/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
+++ b/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
@@ -358,7 +358,7 @@ class Viral_ReplicationSteppable(SteppableBasePy):
             # Test for infection secretion
             if cell.dict['Assembled'] > cell_infection_threshold:
                 cell.type = self.INFECTEDSECRETING
-                cell.dict['ck_production'] = max_ck_secrete_infect
+                #cell.dict['ck_production'] = max_ck_secrete_infect
                 enable_viral_secretion(cell)
 
                 # cyttokine params

--- a/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
+++ b/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
@@ -280,6 +280,7 @@ class CellsInitializerSteppable(SteppableBasePy):
         cell = self.cell_field[self.dim.x // 2, self.dim.y // 2, 0]
         cell.dict['Unpacking'] = 1.0
         cell.type = self.INFECTED
+        cell.dict['ck_production'] = max_ck_secrete_infect
         load_viral_replication_model(self, cell)
 
         for iteration in range(int(initial_immune_seeding)):
@@ -357,6 +358,7 @@ class Viral_ReplicationSteppable(SteppableBasePy):
             # Test for infection secretion
             if cell.dict['Assembled'] > cell_infection_threshold:
                 cell.type = self.INFECTEDSECRETING
+                cell.dict['ck_production'] = max_ck_secrete_infect
                 enable_viral_secretion(cell)
 
                 # cyttokine params
@@ -397,6 +399,7 @@ class Viral_SecretionSteppable(SteppableBasePy):
                 cell.dict['Uptake'] = abs(uptake.tot_amount)
                 if cell.type == self.UNINFECTED:
                     cell.type = self.INFECTED
+                    cell.dict['ck_production'] = max_ck_secrete_infect
                     load_viral_replication_model(self, cell)
                 set_viral_replication_cell_uptake(cell, cell.dict['Uptake'])
 

--- a/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
+++ b/CC3D/Models/BiocIU/SARSCoV2MultiscaleVTM/Model/Simulation/CoronavirusSteppables.py
@@ -79,7 +79,7 @@ max_ck_consume = exp_max_cytokine_consumption_mol * um_to_lat_width ** 3 * s_to_
 max_ck_secrete_im = exp_max_cytokine_immune_secretion_mol * um_to_lat_width ** 3 * s_to_mcs * 1e-15 * pmol_to_cc3d_au  # * cc3d_au/(pixel seconds)
 EC50_ck_immune = exp_EC50_cytokine_immune * um_to_lat_width ** 3 * 1e-15 * pmol_to_cc3d_au  # * cc3d_au/pixel
 
-max_ck_secrete_infect = max_ck_secrete_im
+max_ck_secrete_infect = 10*max_ck_secrete_im
 
 
 # Threshold at which cell infection is evaluated


### PR DESCRIPTION
infected cells secret ck 10x faster than immune (placeholder value), this way they always dominate ck behavior. replaced strait use of parameter in ck secretion/uptake to using a cell dictionary that has the parameter